### PR TITLE
Add an ApiResponse type that wraps API errors

### DIFF
--- a/app/src/main/java/ch/heigvd/pro/b04/android/Authentication/SessionToTokenWithPoll.java
+++ b/app/src/main/java/ch/heigvd/pro/b04/android/Authentication/SessionToTokenWithPoll.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 
 import ch.heigvd.pro.b04.android.Datamodel.Poll;
 import ch.heigvd.pro.b04.android.Datamodel.Session;
+import ch.heigvd.pro.b04.android.Network.LiveDataUtils;
 import ch.heigvd.pro.b04.android.Network.Rockin;
 
 /**
@@ -20,11 +21,11 @@ public class SessionToTokenWithPoll implements Function<Pair<String, Session>, L
     public LiveData<Pair<String, Poll>> apply(Pair<String, Session> input) {
         String token = input.first;
         Session session = input.second;
-        LiveData<Poll> polls = Rockin.api().getPoll(
+        LiveData<Poll> polls = LiveDataUtils.ignorePendingAndErrors(Rockin.api().getPoll(
                 Integer.parseInt(session.getIdModerator()),
                 Integer.parseInt(session.getIdPoll()),
                 token
-        );
+        ));
         return Transformations.map(polls, p -> Pair.create(token, p));
     }
 }

--- a/app/src/main/java/ch/heigvd/pro/b04/android/Authentication/TokenToTokenWithSession.java
+++ b/app/src/main/java/ch/heigvd/pro/b04/android/Authentication/TokenToTokenWithSession.java
@@ -9,13 +9,14 @@ import androidx.lifecycle.Transformations;
 import java.util.function.Function;
 
 import ch.heigvd.pro.b04.android.Datamodel.Session;
+import ch.heigvd.pro.b04.android.Network.LiveDataUtils;
 import ch.heigvd.pro.b04.android.Network.Rockin;
 
 public class TokenToTokenWithSession implements Function<String, LiveData<Pair<String, Session>>> {
 
     @Override
     public LiveData<Pair<String, Session>> apply(String token) {
-        LiveData<Session> sessions = Rockin.api().getSession(token);
+        LiveData<Session> sessions = LiveDataUtils.ignorePendingAndErrors(Rockin.api().getSession(token));
         return Transformations.map(sessions, s -> Pair.create(token, s));
     }
 }

--- a/app/src/main/java/ch/heigvd/pro/b04/android/Network/ApiResponse.java
+++ b/app/src/main/java/ch/heigvd/pro/b04/android/Network/ApiResponse.java
@@ -1,0 +1,97 @@
+package ch.heigvd.pro.b04.android.Network;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * A wrapper class for API responses. This is very similar to the constructs that can be found in
+ * the {@link Optional} class. Instances of this class are immutable, and can either be in a
+ * success or in an error state.
+ *
+ * @param <T> The parameterized type of the response that is received.
+ */
+public final class ApiResponse<T> {
+    private static final int UNDEFINED_CODE = -1;
+
+    private T response;
+    private int errorCode;
+
+    public static <T> ApiResponse<T> of(T value) {
+        return new ApiResponse<>(value);
+    }
+
+    public static <T> ApiResponse<T> ofError(int code) {
+        if (code <= UNDEFINED_CODE) {
+            throw new IllegalArgumentException("The response code must be greater than 0.");
+        }
+        return new ApiResponse<>(code);
+    }
+
+    private ApiResponse(int error) {
+        response = null;
+        errorCode = error;
+    }
+
+    private ApiResponse(T value) {
+        response = Objects.requireNonNull(value);
+        errorCode = UNDEFINED_CODE;
+    }
+
+    public boolean isSuccess() {
+        return errorCode != UNDEFINED_CODE;
+    }
+
+    public boolean isFailure() {
+        return errorCode == UNDEFINED_CODE;
+    }
+
+    public Optional<Integer> error() {
+        if (isFailure()) {
+            return Optional.of(errorCode);
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    public Optional<T> response() {
+        if (isFailure()) {
+            return Optional.empty();
+        } else {
+            return Optional.of(response);
+        }
+    }
+
+    public <S> ApiResponse<S> map(Function<T, S> function) {
+        if (isFailure()) {
+            return new ApiResponse<>(errorCode);
+        } else {
+            return new ApiResponse<>(function.apply(response));
+        }
+    }
+
+    public <S> ApiResponse<S> flatMap(Function<T, ApiResponse<S>> function) {
+        if (isFailure()) {
+            return new ApiResponse<>(errorCode);
+        } else {
+            return function.apply(response);
+        }
+    }
+
+    public T orElseGet(Supplier<? extends T> supplier) {
+        if (isFailure()) {
+            return supplier.get();
+        } else {
+            return response;
+        }
+    }
+
+    public <X extends Throwable> T orElseThrow(Supplier<? extends X> supplier) throws X {
+        if (isFailure()) {
+            throw supplier.get();
+        } else {
+            return response;
+        }
+    }
+}

--- a/app/src/main/java/ch/heigvd/pro/b04/android/Network/LiveDataCallAdapterFactory.java
+++ b/app/src/main/java/ch/heigvd/pro/b04/android/Network/LiveDataCallAdapterFactory.java
@@ -12,6 +12,9 @@ import java.lang.reflect.Type;
 import retrofit2.CallAdapter;
 import retrofit2.Retrofit;
 
+/**
+ * See https://gist.github.com/AkshayChordiya/15cfe7ca1842d6b959e77c04a073a98f for reference.
+ */
 public class LiveDataCallAdapterFactory extends CallAdapter.Factory {
 
     @Nullable
@@ -27,7 +30,16 @@ public class LiveDataCallAdapterFactory extends CallAdapter.Factory {
         }
 
         Type type = CallAdapter.Factory.getParameterUpperBound(0, (ParameterizedType) returnType);
+        Class<?> rawObservableType = getRawType(type);
 
-        return new LiveDataCallAdapter<>(type);
+        if (rawObservableType != ApiResponse.class) {
+            throw new IllegalArgumentException("Type must be an ApiResponse.");
+        }
+
+        if (!(type instanceof ParameterizedType)) {
+            throw new IllegalArgumentException("Response must be parameterized.");
+        }
+
+        return new LiveDataCallAdapter<>(getParameterUpperBound(0, (ParameterizedType) type));
     }
 }

--- a/app/src/main/java/ch/heigvd/pro/b04/android/Network/LiveDataUtils.java
+++ b/app/src/main/java/ch/heigvd/pro/b04/android/Network/LiveDataUtils.java
@@ -1,0 +1,29 @@
+package ch.heigvd.pro.b04.android.Network;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Transformations;
+
+/**
+ * A utilities class with some basic utilities to work with {@link LiveData}, and combining them.
+ */
+public class LiveDataUtils {
+    private LiveDataUtils() {
+        // Nothing to see here.
+    }
+
+    /**
+     * Transforms a {@link LiveData} of {@link ApiResponse} into a {@link LiveData} of the unwrapped
+     * {@link T} type.
+     *
+     * @param liveData The {@link LiveData} to unwrap.
+     * @param <T>      The type to retrieve.
+     * @return An unwrapped {@link LiveData}.
+     */
+    public static <T> LiveData<T> ignorePendingAndErrors(LiveData<ApiResponse<T>> liveData) {
+        return Transformations.switchMap(liveData, input -> input
+                .map(MutableLiveData::new)
+                .orElseGet(MutableLiveData::new)
+        );
+    }
+}

--- a/app/src/main/java/ch/heigvd/pro/b04/android/Network/RockinAPI.java
+++ b/app/src/main/java/ch/heigvd/pro/b04/android/Network/RockinAPI.java
@@ -28,12 +28,12 @@ public interface RockinAPI {
     );
 
     @GET("/session")
-    LiveData<Session> getSession(
+    LiveData<ApiResponse<Session>> getSession(
             @Query("token") String userToken
     );
 
     @GET("/mod/{idModerator}/poll/{idPoll}")
-    LiveData<Poll> getPoll(
+    LiveData<ApiResponse<Poll>> getPoll(
             @Path("idModerator") long idModerator,
             @Path("idPoll") long idPoll,
             @Query("token") String userToken
@@ -62,7 +62,7 @@ public interface RockinAPI {
     );
 
     @GET("/mod/{idModerator}/poll/{idPoll}/question/{idQuestion}/answer")
-    LiveData<List<Answer>> getAnswers(
+    LiveData<ApiResponse<List<Answer>>> getAnswers(
             @Path("idModerator") long idModerator,
             @Path("idPoll") long idPoll,
             @Path("idQuestion") long idQuestion,

--- a/app/src/main/java/ch/heigvd/pro/b04/android/Question/QuestionViewModel.java
+++ b/app/src/main/java/ch/heigvd/pro/b04/android/Question/QuestionViewModel.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import ch.heigvd.pro.b04.android.Datamodel.Answer;
 import ch.heigvd.pro.b04.android.Datamodel.Poll;
 import ch.heigvd.pro.b04.android.Datamodel.Question;
+import ch.heigvd.pro.b04.android.Network.LiveDataUtils;
 import ch.heigvd.pro.b04.android.Network.Rockin;
 import ch.heigvd.pro.b04.android.Utils.LocalDebug;
 import ch.heigvd.pro.b04.android.Utils.PollingLiveData;
@@ -68,18 +69,18 @@ public class QuestionViewModel extends ViewModel {
 
                             return transferred;
                         })
-                );
+        );
 
         currentAnswers.addSource(transformQuestion, answers -> currentAnswers.postValue(answers));
         currentAnswers.addSource(transformDelayed, answers -> currentAnswers.postValue(answers));
     }
 
     private static LiveData<List<Answer>> questionToAnswer(Question question, String token) {
-        return Rockin.api().getAnswers(
+        return LiveDataUtils.ignorePendingAndErrors(Rockin.api().getAnswers(
                 question.getIdModerator(),
                 question.getIdPoll(),
                 question.getIdQuestion(),
-                token);
+                token));
     }
 
     private Callback<ResponseBody> callbackVote = new Callback<ResponseBody>() {
@@ -138,9 +139,9 @@ public class QuestionViewModel extends ViewModel {
         for (Question q : QuestionUtils.getQuestions().getValue()) {
             double newIndex = q.getIndexInPoll();
             if (newIndex > currentIndex && newIndex < candidateIndex) {
-                    candidateIndex = newIndex;
-                    candidate = q;
-                }
+                candidateIndex = newIndex;
+                candidate = q;
+            }
         }
 
         if (candidate != null)
@@ -155,9 +156,9 @@ public class QuestionViewModel extends ViewModel {
 
         int counter = nbCheckedAnswer.getValue();
 
-        if (  question.getAnswerMax() > counter
-           || question.getAnswerMax() == 0
-           || answer.isChecked()) {
+        if (question.getAnswerMax() > counter
+                || question.getAnswerMax() == 0
+                || answer.isChecked()) {
 
             if (answer.isChecked()) {
                 counter++;


### PR DESCRIPTION
This pull request adds a dedicated type for ApiResponses (that **must** be used when a `LiveData` is declared in the `RockingAPI`), as well as a utility function to unwrap it.

In the future, we might want to better handle error cases when we consume `RockinAPI` endpoints with `LiveData`.